### PR TITLE
Express existing okhttp dependency manipulation at project wide scope

### DIFF
--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -63,22 +63,6 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-client</artifactId>
-            <version>${fabric8.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Utils -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -63,12 +63,6 @@ under the License.
             <artifactId>kubernetes-server-mock</artifactId>
             <version>${fabric8.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>mockwebserver</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,33 @@ under the License.
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client</artifactId>
+                <version>${fabric8.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-server-mock</artifactId>
+                <version>${fabric8.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>mockwebserver</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
okhttp version is now consistent across all its modules

```
mvn dependency:tree   | grep com.squareup.okhttp3
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] |  \- com.squareup.okhttp3:logging-interceptor:jar:3.12.12:compile
[INFO] +- com.squareup.okhttp3:mockwebserver:jar:4.12.0:test
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] |  |  \- com.squareup.okhttp3:logging-interceptor:jar:3.12.12:provided
[INFO] +- com.squareup.okhttp3:mockwebserver:jar:4.12.0:test
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] |  |  \- com.squareup.okhttp3:logging-interceptor:jar:3.12.12:provided
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] |  |  \- com.squareup.okhttp3:logging-interceptor:jar:3.12.12:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
[INFO] \- com.squareup.okhttp3:okhttp:jar:4.12.0:compile
```

when in jdk mode, the only okhttp3 dependency is a test one, on the mockwebserver.  (There's a compile time dependency on mockwebserver (org.apache.flink.kubernetes.operator.TestUtils), so we can't make that dependency's inclusion based on the profile).

```
mvn dependency:tree  -Dfabric8.httpclient.impl=jdk -P'!depend-on-okhttp4' | grep com.squareup.okhttp3
mvn dependency:tree  -Dfabric8.httpclient.impl=jdk -P'!depend-on-okhttp4' | grep com.squareup.okhttp3
[INFO] +- com.squareup.okhttp3:mockwebserver:jar:4.12.0:test
[INFO] |  +- com.squareup.okhttp3:okhttp:jar:4.12.0:test
[INFO] \- com.squareup.okhttp3:mockwebserver:jar:4.12.0:test
[INFO]    +- com.squareup.okhttp3:okhttp:jar:4.12.0:test
```

I gave the unit tests a spin locally both with and without `depend-on-okhttp4`.  All is green for me.


